### PR TITLE
[v3.3.0] ApiAction Changes / Custom CoroutineContext / Implement cause field

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,9 +51,11 @@ dependencies {
 
 compileKotlin {
     kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.freeCompilerArgs += ["-Xuse-experimental=kotlin.Experimental"]
 }
 compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.freeCompilerArgs += ["-Xuse-experimental=kotlin.Experimental"]
 }
 
 dokka {

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 group "jp.nephy"
-version "3.2.3"
+version "3.3.0"
 
 buildscript {
     ext.kotlin_version = "1.3.11"
-    ext.ktor_version = "1.0.1"
+    ext.ktor_version = "1.1.1"
 
     repositories {
         mavenCentral()
@@ -26,9 +26,9 @@ apply plugin: "signing"
 repositories {
     mavenCentral()
     jcenter()
-    maven { url "https://dl.bintray.com/kotlin/kotlin-eap" }
-    maven { url "https://dl.bintray.com/kotlin/ktor" }
-    maven { url "https://dl.bintray.com/kotlin/kotlinx" }
+    maven { url "https://kotlin.bintray.com/kotlin-eap" }
+    maven { url "https://kotlin.bintray.com/ktor" }
+    maven { url "https://kotlin.bintray.com/kotlinx" }
 }
 
 dependencies {
@@ -40,7 +40,7 @@ dependencies {
     testCompile "io.ktor:ktor-client-jetty:$ktor_version"
     testCompile "io.ktor:ktor-client-okhttp:$ktor_version"
 
-    compile "jp.nephy:jsonkt:4.1"
+    compile "jp.nephy:jsonkt:4.2"
     testCompile "com.twitter.twittertext:twitter-text:3.0.1"
 
     compile "io.github.microutils:kotlin-logging:1.6.22"

--- a/src/main/kotlin/jp/nephy/penicillin/core/PenicillinException.kt
+++ b/src/main/kotlin/jp/nephy/penicillin/core/PenicillinException.kt
@@ -6,9 +6,10 @@ import io.ktor.client.request.HttpRequest
 import io.ktor.client.response.HttpResponse
 import jp.nephy.penicillin.core.i18n.LocalizedString
 
-open class PenicillinException(override val message: String, val error: TwitterErrorMessage? = null, val request: HttpRequest? = null, val response: HttpResponse? = null): Exception()
-class PenicillinLocalizedException(localizedString: LocalizedString, request: HttpRequest? = null, response: HttpResponse? = null, vararg args: Any?):
-    PenicillinException(localizedString.format(*args), request = request, response = response)
+open class PenicillinException(override val message: String, val error: TwitterErrorMessage? = null, val request: HttpRequest? = null, val response: HttpResponse? = null,
+    override val cause: Throwable? = null): Exception()
+class PenicillinLocalizedException(localizedString: LocalizedString, request: HttpRequest? = null, response: HttpResponse? = null, cause: Throwable? = null, vararg args: Any?):
+    PenicillinException(localizedString.format(*args), request = request, response = response, cause = cause)
 
 enum class TwitterErrorMessage(val code: Int, val title: String, val description: String) {
     InvalidCoordinates(3, "Invalid coordinates.", "Corresponds with HTTP 400. The coordinates provided as parameters were not valid for the request."), NoLocationAssociatedWithTheSpecifiedIPAddress(
@@ -120,11 +121,12 @@ enum class TwitterErrorMessage(val code: Int, val title: String, val description
 
 class TwitterApiError(code: Int, title: String, content: String, request: HttpRequest, response: HttpResponse): Exception() {
     init {
-        val message = TwitterErrorMessage.values().find { it.code == code } ?: throw PenicillinLocalizedException(LocalizedString.UnknownApiError, request, response, code, title, content)
+        val message = TwitterErrorMessage.values().find { it.code == code } ?: throw PenicillinLocalizedException(LocalizedString.UnknownApiError, request, response, null, code, title, content)
 
-        throw PenicillinException("${message.title} (${message.code}): ${message.description} (${request.url})", message, request, response)
+        throw PenicillinException("${message.title} (${message.code}): ${message.description} (${request.url})", message, request, response, this)
     }
 }
+
 //for x in lxml.html.fromstring(requests.get("https://developer.twitter.com/en/docs/basics/response-codes").text).xpath("//*[@id=\"component-wrapper\"]/div[4]/div/div[2]/div[3]/div/div/div/div/div/div/div/div[3]/table/tbody/tr"):
 //    p = x.xpath("td")
 //    code = p[0].text_content().strip()

--- a/src/main/kotlin/jp/nephy/penicillin/core/PenicillinResponse.kt
+++ b/src/main/kotlin/jp/nephy/penicillin/core/PenicillinResponse.kt
@@ -14,7 +14,6 @@ import jp.nephy.penicillin.models.*
 import jp.nephy.penicillin.models.special.AccessLevel
 import jp.nephy.penicillin.models.special.RateLimit
 import java.io.Closeable
-import kotlin.coroutines.CoroutineContext
 import kotlin.reflect.KClass
 
 interface PenicillinResponse: Closeable {
@@ -72,14 +71,14 @@ data class PenicillinCursorJsonObjectResponse<M: PenicillinCursorModel>(
     fun next() = byCursor(result.nextCursor)
     fun previous() = byCursor(result.previousCursor)
 
-    fun untilLast(context: CoroutineContext? = null) = sequence {
+    fun untilLast() = sequence {
         yield(this@PenicillinCursorJsonObjectResponse)
-        yieldAll(next().untilLast(context))
+        yieldAll(next().untilLast())
     }
 
     fun byCursor(cursor: Long): PenicillinCursorJsonObjectAction<M> {
         if (cursor == 0L) {
-            throw PenicillinLocalizedException(LocalizedString.CursorIsZero)
+            throw PenicillinLocalizedException(LocalizedString.CursorIsZero, request, response)
         }
 
         action.request.builder.parameter("cursor" to cursor)

--- a/src/main/kotlin/jp/nephy/penicillin/core/Session.kt
+++ b/src/main/kotlin/jp/nephy/penicillin/core/Session.kt
@@ -49,8 +49,5 @@ data class Session(val httpClient: HttpClient, override val coroutineContext: Co
 
     override fun close() {
         httpClient.close()
-        if (coroutineContext is Closeable) {
-            coroutineContext.close()
-        }
     }
 }

--- a/src/main/kotlin/jp/nephy/penicillin/core/Session.kt
+++ b/src/main/kotlin/jp/nephy/penicillin/core/Session.kt
@@ -7,11 +7,12 @@ import io.ktor.http.HttpMethod
 import io.ktor.http.URLProtocol
 import jp.nephy.penicillin.core.auth.Credentials
 import jp.nephy.penicillin.endpoints.EndpointHost
-import kotlinx.coroutines.ExecutorCoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import mu.KLogger
 import java.io.Closeable
+import kotlin.coroutines.CoroutineContext
 
-data class Session(val httpClient: HttpClient, val dispatcher: ExecutorCoroutineDispatcher, val logger: KLogger, val credentials: Credentials, val option: ClientOption): Closeable {
+data class Session(val httpClient: HttpClient, override val coroutineContext: CoroutineContext, val logger: KLogger, val credentials: Credentials, val option: ClientOption): Closeable, CoroutineScope {
     fun call(
         method: HttpMethod, path: String, host: EndpointHost = EndpointHost.Default, protocol: URLProtocol = URLProtocol.HTTPS, builder: PenicillinRequestBuilder.() -> Unit = {}
     ): PenicillinRequest {
@@ -48,6 +49,8 @@ data class Session(val httpClient: HttpClient, val dispatcher: ExecutorCoroutine
 
     override fun close() {
         httpClient.close()
-        dispatcher.close()
+        if (coroutineContext is Closeable) {
+            coroutineContext.close()
+        }
     }
 }

--- a/src/main/kotlin/jp/nephy/penicillin/core/SessionBuilder.kt
+++ b/src/main/kotlin/jp/nephy/penicillin/core/SessionBuilder.kt
@@ -14,8 +14,7 @@ import io.ktor.http.Cookie
 import io.ktor.util.KtorExperimentalAPI
 import jp.nephy.penicillin.core.auth.Credentials
 import jp.nephy.penicillin.core.emulation.EmulationMode
-import kotlinx.coroutines.ObsoleteCoroutinesApi
-import kotlinx.coroutines.newFixedThreadPoolContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
 import java.util.concurrent.TimeUnit
@@ -46,13 +45,11 @@ class SessionBuilder {
 
     data class DispatcherConfig(val coroutineContext: CoroutineContext, val connectionThreadsCount: Int?) {
         class Builder {
-            var workingThreadsCount = minOf(1, Runtime.getRuntime().availableProcessors() / 2)
             var connectionThreadsCount: Int? = null
-            var coroutineContext: CoroutineContext? = null
+            var coroutineContext: CoroutineContext = Dispatchers.Default
 
-            @UseExperimental(ObsoleteCoroutinesApi::class)
             internal fun build(): DispatcherConfig {
-                return DispatcherConfig(coroutineContext ?: newFixedThreadPoolContext(workingThreadsCount, "Penicillin"), connectionThreadsCount)
+                return DispatcherConfig(coroutineContext, connectionThreadsCount)
             }
         }
     }

--- a/src/main/kotlin/jp/nephy/penicillin/core/SessionBuilder.kt
+++ b/src/main/kotlin/jp/nephy/penicillin/core/SessionBuilder.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.newFixedThreadPoolContext
 import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
 import java.util.concurrent.TimeUnit
+import kotlin.coroutines.CoroutineContext
 
 class SessionBuilder {
     private var credentialsBuilder: Credentials.Builder.() -> Unit = {}
@@ -43,13 +44,15 @@ class SessionBuilder {
         dispatcherConfigBuilder = builder
     }
 
-    data class DispatcherConfig(val workingThreadsCount: Int, val connectionThreadsCount: Int?) {
+    data class DispatcherConfig(val coroutineContext: CoroutineContext, val connectionThreadsCount: Int?) {
         class Builder {
             var workingThreadsCount = minOf(1, Runtime.getRuntime().availableProcessors() / 2)
             var connectionThreadsCount: Int? = null
+            var coroutineContext: CoroutineContext? = null
 
+            @UseExperimental(ObsoleteCoroutinesApi::class)
             internal fun build(): DispatcherConfig {
-                return DispatcherConfig(workingThreadsCount, connectionThreadsCount)
+                return DispatcherConfig(coroutineContext ?: newFixedThreadPoolContext(workingThreadsCount, "Penicillin"), connectionThreadsCount)
             }
         }
     }
@@ -94,7 +97,7 @@ class SessionBuilder {
         httpClient = client
     }
 
-    @UseExperimental(ObsoleteCoroutinesApi::class, KtorExperimentalAPI::class)
+    @UseExperimental(KtorExperimentalAPI::class)
     internal fun build(): Session {
         val cookieConfig = CookieConfig.Builder().apply(cookieConfigBuilder).build()
         val dispatcherConfig = DispatcherConfig.Builder().apply(dispatcherConfigBuilder).build()
@@ -129,10 +132,9 @@ class SessionBuilder {
             httpClientConfig?.invoke(this)
         }
         val authorizationData = Credentials.Builder().apply(credentialsBuilder).build()
-        val dispatcher = newFixedThreadPoolContext(dispatcherConfig.workingThreadsCount, "Penicillin")
         val logger = KotlinLogging.logger("Penicillin.Client")
 
-        return Session(httpClient, dispatcher, logger, authorizationData, ClientOption(maxRetries, retryInMillis, emulationMode, skipEmulationChecking))
+        return Session(httpClient, dispatcherConfig.coroutineContext, logger, authorizationData, ClientOption(maxRetries, retryInMillis, emulationMode, skipEmulationChecking))
     }
 }
 

--- a/src/main/kotlin/jp/nephy/penicillin/core/streaming/StreamProcessor.kt
+++ b/src/main/kotlin/jp/nephy/penicillin/core/streaming/StreamProcessor.kt
@@ -8,20 +8,19 @@ import jp.nephy.penicillin.core.unescapeHTML
 import kotlinx.coroutines.*
 import kotlinx.coroutines.io.readUTF8Line
 import java.io.Closeable
-import kotlin.coroutines.CoroutineContext
 
 class StreamProcessor<L: StreamListener, H: StreamHandler<L>>(private var result: PenicillinStreamResponse<L, H>, private val handler: H): Closeable {
     private val job = Job()
 
-    fun startBlocking(autoReconnect: Boolean = true, context: CoroutineContext? = null) = apply {
-        runBlocking((context ?: result.action.request.session.dispatcher) + job) {
+    fun startBlocking(autoReconnect: Boolean = true) = apply {
+        runBlocking(result.action.request.session.coroutineContext + job) {
             loop(autoReconnect)
             close()
         }
     }
 
-    fun startAsync(autoReconnect: Boolean = true, scope: CoroutineScope = GlobalScope, context: CoroutineContext? = null) = apply {
-        scope.launch((context ?: result.action.request.session.dispatcher) + job) {
+    fun startAsync(autoReconnect: Boolean = true) = apply {
+        result.action.request.session.launch(job) {
             loop(autoReconnect)
             close()
         }


### PR DESCRIPTION
## ApiAction
- queue / queueWithTimeout の実装を `runCatching` で書き直しました。
- queue / queueWithTimeout のラムダ内で 中断関数が使えるようになりました。
- context: CoroutineContext や start: CoroutineStart などの引数を削除しました。

## Session
- `dispatcher: ExecutorCoroutineDispatcher` は `coroutineContext: CoroutineContext` に名前が変更されました。
- `Session` クラスは `CoroutineScope` を実装しています。

## SessionBuilder
- `dispatcher {}` ブロック内で `coroutineContext` を任意に設定できるようになりました。

## PenicillinException
- `Exception.cause` を override して例外の原因を追いやすくなりました。

## ライブラリ
- Ktor 1.0.1 → 1.1.1
- JsonKt 4.1 → 4.2
