### PR TITLE
[v3.3.4] CursorAPI like Twitter4J

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group "jp.nephy"
-version "3.3.3"
+version "3.3.4"
 
 buildscript {
     ext.kotlin_version = "1.3.11"

--- a/src/main/kotlin/jp/nephy/penicillin/core/PenicillinResponse.kt
+++ b/src/main/kotlin/jp/nephy/penicillin/core/PenicillinResponse.kt
@@ -84,7 +84,9 @@ data class PenicillinCursorJsonObjectResponse<M: PenicillinCursorModel>(
 
     fun untilLast() = sequence {
         yield(this@PenicillinCursorJsonObjectResponse)
-        yieldAll(next().untilLast())
+        if (hasNext()) {
+            yieldAll(next().untilLast())
+        }
     }
 
     fun byCursor(cursor: Long): PenicillinCursorJsonObjectAction<M> {

--- a/src/main/kotlin/jp/nephy/penicillin/core/PenicillinResponse.kt
+++ b/src/main/kotlin/jp/nephy/penicillin/core/PenicillinResponse.kt
@@ -68,8 +68,19 @@ data class PenicillinCursorJsonObjectResponse<M: PenicillinCursorModel>(
     override val json = result.json
     override val headers = ResponseHeaders(response.headers)
 
-    fun next() = byCursor(result.nextCursor)
-    fun previous() = byCursor(result.previousCursor)
+    val nextCursor: Long
+        get() = result.nextCursor
+    fun hasNext(): Boolean {
+        return nextCursor > 0
+    }
+    fun next() = byCursor(nextCursor)
+
+    val previousCursor: Long
+        get() = result.previousCursor
+    fun hasPrevious(): Boolean {
+        return previousCursor > 0
+    }
+    fun previous() = byCursor(previousCursor)
 
     fun untilLast() = sequence {
         yield(this@PenicillinCursorJsonObjectResponse)

--- a/src/main/kotlin/jp/nephy/penicillin/core/SearchCursorExtension.kt
+++ b/src/main/kotlin/jp/nephy/penicillin/core/SearchCursorExtension.kt
@@ -1,0 +1,11 @@
+package jp.nephy.penicillin.core
+
+import jp.nephy.penicillin.models.Search
+
+fun PenicillinJsonObjectResponse<Search>.next(): PenicillinJsonObjectAction<Search> {
+    for ((k, v) in result.searchMetadata.nextResults.removePrefix("?").split("&").map { it.split("=", limit = 2) }) {
+        action.request.builder.parameter(k to v)
+    }
+
+    return action.request.jsonObject()
+}

--- a/src/main/kotlin/jp/nephy/penicillin/core/SearchCursorExtension.kt
+++ b/src/main/kotlin/jp/nephy/penicillin/core/SearchCursorExtension.kt
@@ -3,9 +3,11 @@ package jp.nephy.penicillin.core
 import jp.nephy.penicillin.models.Search
 
 fun PenicillinJsonObjectResponse<Search>.next(): PenicillinJsonObjectAction<Search> {
-    for ((k, v) in result.searchMetadata.nextResults.removePrefix("?").split("&").map { it.split("=", limit = 2) }) {
+    result.searchMetadata.nextResults?.removePrefix("?")?.split("&")?.map { it.split("=", limit = 2) }?.forEach { (k, v) ->
         action.request.builder.parameter(k to v)
     }
 
     return action.request.jsonObject()
 }
+
+fun PenicillinJsonObjectResponse<Search>.hasNext() = !result.searchMetadata.nextResults.isNullOrBlank()

--- a/src/main/kotlin/jp/nephy/penicillin/models/SearchMetadata.kt
+++ b/src/main/kotlin/jp/nephy/penicillin/models/SearchMetadata.kt
@@ -10,7 +10,7 @@ data class SearchMetadata(override val json: JsonObject): PenicillinModel {
     val count by int
     val maxId by long("max_id")
     val maxIdStr by string("max_id_str")
-    val nextResults by string("next_results")
+    val nextResults by nullableString("next_results")
     val query by string
     val refreshUrl by string("refresh_url")
     val sinceId by int("since_id")


### PR DESCRIPTION
PenicillinCursorJsonObjectAction<M> に `.hasNext()`, `.hasPrevious()`, `.nextCursor`, `.previousCursor` のメンバーを追加。

`.untilLast()` が 1つの場合, 失敗するバグを修正。